### PR TITLE
Create CircleCI structure for datalake-query-db-consumer repo 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,69 @@
+version: 2.1
+orbs:
+  python: circleci/python@1.3.2
+parameters:
+  aws-region:
+    type: string
+    default: "us-west-2"
+jobs:
+  build:
+    docker:
+      - image: cimg/python:3.9.1
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+#      - python/install-packages:
+#          pkg-manager: poetry
+      - run:
+          name: install dependencies and run tests
+          command: |
+            python3 -m venv .venv
+            . .venv/bin/activate
+            pip install -e . --index-url https://pypi.org/simple/
+            pip install tox --index-url https://pypi.org/simple/
+            docker-compose run test
+  # Release a Docker base image.
+  release_images:
+    docker:
+      - image: cimg/base:2022.02
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+      - run:
+          name: Build Docker Image and Push to ECR
+          command: |
+            REGISTRY=711570343235.dkr.ecr.us-west-2.amazonaws.com
+            IMAGE_NAME=datalake-query-db-consumer
+            if [[ -n "${CIRCLE_TAG}" ]]; then
+              TAG="${CIRCLE_TAG}"
+            else
+              TAG="${CIRCLE_BRANCH}"
+            fi
+            # Build docker image and tag
+            docker build -t "${IMAGE_NAME}:latest" .
+            COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+            docker tag "${IMAGE_NAME}:latest" "${REGISTRY}/${IMAGE_NAME}:${COMMIT}"
+            docker push "${REGISTRY}/${IMAGE_NAME}:${TAG}"
+            docker push "${REGISTRY}/${IMAGE_NAME}:${COMMIT}"
+workflows:
+  build-release:
+    jobs:
+      - build:
+          context: Build
+          filters:
+            tags:
+              only: /.*/
+
+      - release_images:
+          context: Deploy
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - main
+                - /feature-.*/
+            tags:
+              only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,13 @@
 version: 2.1
 orbs:
   python: circleci/python@1.3.2
-parameters:
-  aws-region:
-    type: string
-    default: "us-west-2"
+  aws-ecr: circleci/aws-ecr@6.15.3
 jobs:
   build:
     docker:
       - image: cimg/python:3.9.1
     steps:
       - checkout
-      - setup_remote_docker:
-          docker_layer_caching: true
-#      - python/install-packages:
-#          pkg-manager: poetry
       - run:
           name: install dependencies and run tests
           command: |
@@ -22,13 +15,16 @@ jobs:
             . .venv/bin/activate
             pip install -e . --index-url https://pypi.org/simple/
             pip install tox --index-url https://pypi.org/simple/
-            docker-compose run test
   # Release a Docker base image.
   release_images:
     docker:
       - image: cimg/base:2022.02
+    environment:
+      AWS_REGION: us-west-2
+      AWS_ECR_ACCOUNT_URL: 711570343235.dkr.ecr.us-west-2.amazonaws.com
     steps:
       - checkout
+      - aws-ecr/ecr-login
       - setup_remote_docker:
           docker_layer_caching: true
       - run:
@@ -44,6 +40,7 @@ jobs:
             # Build docker image and tag
             docker build -t "${IMAGE_NAME}:latest" .
             COMMIT=$(git rev-parse --short HEAD 2>/dev/null)
+            docker tag "${IMAGE_NAME}:latest" "${REGISTRY}/${IMAGE_NAME}:${TAG}"
             docker tag "${IMAGE_NAME}:latest" "${REGISTRY}/${IMAGE_NAME}:${COMMIT}"
             docker push "${REGISTRY}/${IMAGE_NAME}:${TAG}"
             docker push "${REGISTRY}/${IMAGE_NAME}:${COMMIT}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.9
 
+# Necessary to install BBSM packages on the VPN locally. Uncomment ENV and add back trusted-host/index-url flag to pip
+#ENV PIP_INDEX_URL="https://artprod.dev.bloomberg.com/artifactory/api/pypi/bloomberg-pypi/simple"
+
 ARG SQLALCHEMY_DEPENDENCIES=""
 
 WORKDIR /datalakequerydbconsumer
@@ -9,5 +12,6 @@ COPY . .
 COPY ./log_config.yaml /opt/config/datalakequerydbconsumer/log_config.yaml
 
 RUN python3.9 -m pip install ${SQLALCHEMY_DEPENDENCIES} tox .
+#--trusted-host artprod.dev.bloomberg.com --index-url=$PIP_INDEX_URL
 
 ENTRYPOINT [ "python3.9", "-m", "bloomberg.datalake.datalakequerydbconsumer" ]


### PR DESCRIPTION
Integrate CircleCI structure like we've done for our current repos to forked datalake-query-db-consumer repo. This is part of overall work to leverage BBG microservices to log queries on our Trino cluster.

Ticket: https://jira.prod.bloomberg.com/browse/BBSMDP-584